### PR TITLE
店舗詳細の実装・カードアイコンの位置をトップにする・起動時にプログレスviewを表示

### DIFF
--- a/NearbyRestaurantBrochure/NearbyRestaurantBrochure/ContentView.swift
+++ b/NearbyRestaurantBrochure/NearbyRestaurantBrochure/ContentView.swift
@@ -5,24 +5,41 @@ struct ContentView: View {
     @StateObject private var locationManager = LocationManager()
     @StateObject private var viewModel = ShopListViewModel()
     
+    private var isInitialLoading: Bool {
+        viewModel.shops.isEmpty && viewModel.loadingState != .loaded
+    }
+    
     var body: some View {
-        ShopListView(viewModel: viewModel)
-            .onAppear {
-                locationManager.startUpdating()
+        ZStack {
+            ShopListView(viewModel: viewModel)
+            
+            //起動時のプログレスview
+            if isInitialLoading {
+                VStack(spacing: 12) {
+                    ProgressView()
+                        .scaleEffect(1.2)
+                    Text("読み込み中...")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(20)
+                .background(.thinMaterial)
+                .clipShape(RoundedRectangle(cornerRadius: 16))
             }
-            .onChange(of: locationManager.coordinate) { _, newValue in
-                viewModel.coordinate = newValue
-                if newValue != nil && viewModel.shops.isEmpty {
-                    Task {
-                        await viewModel.fetchShops()
-                    }
+        }
+        .onAppear {
+            locationManager.startUpdating()
+        }
+        .onChange(of: locationManager.coordinate) { _, newValue in
+            viewModel.coordinate = newValue
+            if newValue != nil && viewModel.shops.isEmpty {
+                Task {
+                    await viewModel.fetchShops()
                 }
             }
+        }
     }
 }
-
-
-
 
 #Preview {
     ContentView()

--- a/NearbyRestaurantBrochure/NearbyRestaurantBrochure/Views/MapView.swift
+++ b/NearbyRestaurantBrochure/NearbyRestaurantBrochure/Views/MapView.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+import MapKit
+
+struct MapView: View {
+    let shop: Shop
+    var searchKey: String {shop.address ?? ""}
+    @State private var targetCoordinate: CLLocationCoordinate2D?
+    @State private var cameraPosition: MapCameraPosition = .automatic
+    
+    var body: some View {
+        Map(position: $cameraPosition) {
+
+            if let coordinate = targetCoordinate {
+                Marker(shop.name ?? "店舗", coordinate: coordinate)
+            }
+        }
+        .task(id: searchKey) {
+            await searchAddress()
+        }
+    }
+
+    private func searchAddress() async {
+        guard !searchKey.isEmpty else { return }
+        
+        let request = MKLocalSearch.Request()
+        request.naturalLanguageQuery = searchKey
+        let search = MKLocalSearch(request: request)
+        
+        do {
+            let response = try await search.start()
+            
+            if let firstItem = response.mapItems.first {
+                let coordinate: CLLocationCoordinate2D?
+                if #available(iOS 26.0, *) {
+                    coordinate = firstItem.location.coordinate
+                } else {
+                    coordinate = firstItem.placemark.coordinate
+                }
+                if let coordinate {
+                    self.targetCoordinate = coordinate
+                    self.cameraPosition = .region(MKCoordinateRegion(
+                        center: coordinate,
+                        latitudinalMeters: 250,
+                        longitudinalMeters: 250
+                    ))
+                }
+            }
+        } catch {
+            print("住所の検索に失敗しました: \(error.localizedDescription)")
+        }
+    }
+}
+

--- a/NearbyRestaurantBrochure/NearbyRestaurantBrochure/Views/ShopCardView.swift
+++ b/NearbyRestaurantBrochure/NearbyRestaurantBrochure/Views/ShopCardView.swift
@@ -29,7 +29,7 @@ struct ShopCardView: View {
                     .font(.title3)
                     .foregroundStyle(Color(.black))
                     .bold()
-                HStack{
+                HStack(alignment: .top){
                     Image(systemName: "mappin.and.ellipse.circle")
                         .foregroundStyle(Color(.apricot))
                     Text(shop.access ?? "")

--- a/NearbyRestaurantBrochure/NearbyRestaurantBrochure/Views/ShopDetailView.swift
+++ b/NearbyRestaurantBrochure/NearbyRestaurantBrochure/Views/ShopDetailView.swift
@@ -1,0 +1,102 @@
+import SwiftUI
+
+struct ShopDetailView: View {
+    let shop: Shop
+    
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                
+                // ヘッダー画像
+                headerImage
+                
+                VStack(alignment: .leading) {
+                    
+                    // 店舗情報
+                    VStack(alignment: .leading) {
+                        Text(shop.name ?? "店舗名不明")
+                            .font(.title)
+                            .bold()
+                        
+                        // 予算
+                        if let budget = shop.budget?.average {
+                            Label(budget, systemImage: "yensign.circle")
+                                .font(.body)
+                                .bold()
+                                .foregroundStyle(.orange)
+                        }
+                    }
+                    
+                    Divider()
+                        .padding(.bottom, 8)
+                    
+                    // 営業時間・住所・アクセス・地図
+                    VStack(alignment: .leading, spacing: 24) {
+                        // 営業時間
+                        if let open = shop.open {
+                            DetailSection(title: "営業時間", icon: "clock", text: open)
+                        }
+                        
+                        if let address = shop.address {
+                            DetailSection(title: "住所", icon: "map", text: address)
+                        }
+                        
+                        if let access = shop.access {
+                            DetailSection(title: "アクセス", icon: "figure.walk", text: access)
+                        }
+                        
+                        MapView(shop: shop)
+                            .frame(height: 240)
+                            .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                                    .stroke(.separator, lineWidth: 0.5)
+                            )
+                    }
+                }
+                .padding(.horizontal, 20)
+                .padding(.vertical, 24)
+            }
+        }
+        .navigationTitle("店舗詳細")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+    
+    private var headerImage: some View {
+        Group {
+            if let imageUrlString = shop.photo?.pc?.m ?? shop.photo?.mobile?.l,
+               let url = URL(string: imageUrlString) {
+                AsyncImage(url: url) { image in
+                    image
+                        .resizable()
+                        .scaledToFill()
+                } placeholder: {
+                    Rectangle().fill(Color(UIColor.secondarySystemBackground))
+                }
+                .frame(height: 200)
+                .clipped()
+            }
+        }
+    }
+}
+
+struct DetailSection: View {
+    let title: String
+    let icon: String
+    let text: String
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 6) {
+                Image(systemName: icon)
+                Text(title)
+            }
+            .font(.footnote)
+            .fontWeight(.bold)
+            .foregroundStyle(.orange)
+            Text(text)
+                .font(.body)
+                .foregroundStyle(.primary)
+        }
+    }
+}

--- a/NearbyRestaurantBrochure/NearbyRestaurantBrochure/Views/ShopListView.swift
+++ b/NearbyRestaurantBrochure/NearbyRestaurantBrochure/Views/ShopListView.swift
@@ -20,19 +20,24 @@ struct ShopListView: View {
                             .id("top")
                         LazyVStack(spacing: 20) {
                             ForEach(viewModel.shops, id: \.name) { shop in
-                                ShopCardView(shop: shop)
-                                    .scrollTransition(.interactive) { content, phase in
-                                        content
-                                            .opacity(phase.isIdentity ? 1.0 : 0.5)
-                                    }
-                                    .redacted(reason: isLoading ? .placeholder : [])
-                                    .shimmering(active: isLoading)
+                                NavigationLink{
+                                    ShopDetailView(shop: shop)
+                                }label: {
+                                    ShopCardView(shop: shop)
+                                        .scrollTransition(.interactive) { content, phase in
+                                            content
+                                                .opacity(phase.isIdentity ? 1.0 : 0.5)
+                                        }
+                                        .redacted(reason: isLoading ? .placeholder : [])
+                                        .shimmering(active: isLoading)
+                                }
+                                .buttonStyle(.plain)
                             }
-                        }
-                        .onChange(of: viewModel.loadingState) { _, newState in
-                            if newState == .loaded {
-                                withAnimation {
-                                    proxy.scrollTo("top", anchor: .top)
+                            .onChange(of: viewModel.loadingState) { _, newState in
+                                if newState == .loaded {
+                                    withAnimation {
+                                        proxy.scrollTo("top", anchor: .top)
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
close #4 
close #10 

- 店舗詳細viewを実装
- 店舗カードのsfシンボルとテキストをの整列をtopに変更
- 起動時にロードを表示
- 詳細viewに地図を表示